### PR TITLE
read VERSION > manpage, fix MANDIR, set mode for executable just to be sure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(EXEC): $(OBJS)
 install: all
 	$(INSTALL) -m 755 -D $(EXEC) $(BINDIR)/$(EXEC)
 	-mkdir -p $(MANDIR)
-	-sed "s/VERSION/$(VERSION)/g" $(EXEC).6 | gzip -c > $(MANDIR)/$(EXEC).6.gz
+	-sed "s/%VERSION%/$(VERSION)/g" $(EXEC).6 | gzip -c > $(MANDIR)/$(EXEC).6.gz
 	-chmod 644 $(MANDIR)/$(EXEC).6.gz
 
 install-strip:

--- a/curseofwar.6
+++ b/curseofwar.6
@@ -1,4 +1,4 @@
-.TH CURSEOFWAR "6" "July 2013" "curseofwar" "vVERSION"
+.TH CURSEOFWAR "6" "July 2013" "curseofwar" "v%VERSION%"
 .SH NAME
 curseofwar \- Real Time Strategy Game for Linux
 .SH SYNOPSIS


### PR DESCRIPTION
This is a suggestion how we could generate the manpage dynamically. It works without any template files, but moves the gzipman step to make install. I oriented myself on dwm's Makefile. Additionally the manpage now install to the correct directory. 
I also took the freedom to include two minor (imo) improvements:
- make install now compiles the binaries if not already done
- make install now explicitly sets the mode for the executable

Let me know what you think.

(For the future: should I put all those changes in one single commit or rather split it into several? In this case it would be 4 commits: One for the version stuff, the second for the MANDIR, the third for make install: all and the last one for the executable mode.)
