### PR TITLE
move DESTDIR to BIN/MANDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 SHELL = /bin/sh
 CC      = gcc
 INSTALL = install
-PREFIX ?= $(DESTDIR)/usr
+PREFIX ?= /usr
 MANPREFIX=$(PREFIX)/share/man
-BINDIR = $(PREFIX)/bin
-MANDIR = $(MANPREFIX)/man6
+BINDIR = $(DESTDIR)$(PREFIX)/bin
+MANDIR = $(DESTDIR)$(MANPREFIX)/man6
 
 SRCS    = $(wildcard *.c)
 HDRS    = $(wildcard *.h)


### PR DESCRIPTION
Afaik this is the standard procedure and enables more flexible handling of make install.
For example:
make DESTDIR=$PKG MANPREFIX=/usr/man install
instead of
make DESTDIR=$PKG MANPREFIX=$PKG/usr/man install
