### PR TITLE
Install changelog.gz and Makefile fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 new
   * Added timeline plot showing populations of the countries (with option -T)
+  * Install changelog.gz
+  * Some installation fixes in Makefile
 
 version 1.1.7 2013-07-22
   * Icons 32x32 and 16x16

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
-
 SHELL = /bin/sh
 CC      = gcc
 INSTALL = install
+EXEC   = curseofwar
+
 PREFIX ?= /usr
-MANPREFIX=$(PREFIX)/share/man
+MANPREFIX = $(PREFIX)/share/man
+
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 MANDIR = $(DESTDIR)$(MANPREFIX)/man6
+DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/$(EXEC)
 
 SRCS    = $(wildcard *.c)
 HDRS    = $(wildcard *.h)
 OBJS    = $(patsubst %.c,%.o,$(SRCS))
-EXEC   = curseofwar
 EXECS = $(EXEC)
 CFLAGS  += -Wall -O2
 LDLIBS += -lncurses -lm 
@@ -32,16 +34,20 @@ $(EXEC): $(OBJS)
 
 install: all
 	$(INSTALL) -m 755 -D $(EXEC) $(BINDIR)/$(EXEC)
-	-mkdir -p $(MANDIR)
+	$(INSTALL) -m 755 -d $(MANDIR)
 	-sed "s/%VERSION%/$(VERSION)/g" $(EXEC).6 | gzip -c > $(MANDIR)/$(EXEC).6.gz
 	-chmod 644 $(MANDIR)/$(EXEC).6.gz
+	$(INSTALL) -m 755 -d $(DOCDIR)
+	-cat CHANGELOG | gzip -c > $(DOCDIR)/changelog.gz
+	-chmod 644 $(DOCDIR)/changelog.gz
 
 install-strip:
 	$(INSTALL) -D -s $(EXEC) $(BINDIR)/$(EXEC)
 
 uninstall:
-	  -rm $(BINDIR)/$(EXEC)
-	  -rm -f $(MANDIR)/$(EXEC).6.gz
+	-rm $(BINDIR)/$(EXEC)
+	-rm -f $(MANDIR)/$(EXEC).6.gz
+	-rm $(DOCDIR)/changelog.gz
 
 show-path:
 	@echo would install to ${BINDIR}


### PR DESCRIPTION
Tested.
Proof:

[15:29:02]abalashov@abalashow-ws:~/Dropbox/develop/curseofwar/repo/curseofwar $ sudo rm -rf /tmp/curs/

[15:29:33]abalashov@abalashow-ws:~/Dropbox/develop/curseofwar/repo/curseofwar $ sudo make DESTDIR=/tmp/curs/ install
install -m 755 -D curseofwar /tmp/curs//usr/bin/curseofwar
install -m 775 -d /tmp/curs//usr/share/man/man6
sed "s/%VERSION%/`cat VERSION`/g" curseofwar.6 | gzip -c > /tmp/curs//usr/share/man/man6/curseofwar.6.gz
install -m 755 -d /tmp/curs//usr/share/doc/curseofwar
cat CHANGELOG | gzip -c > /tmp/curs//usr/share/doc/curseofwar/changelog.gz
chmod 644 /tmp/curs//usr/share/man/man6/curseofwar.6.gz

[15:29:45]abalashov@abalashow-ws:~/Dropbox/develop/curseofwar/repo/curseofwar $ tree /tmp/curs/
/tmp/curs/
└── usr
    ├── bin
    │   └── curseofwar
    └── share
        ├── doc
        │   └── curseofwar
        │       └── changelog.gz
        └── man
            └── man6
                └── curseofwar.6.gz

7 directories, 3 files

[15:29:49]abalashov@abalashow-ws:~/Dropbox/develop/curseofwar/repo/curseofwar $ sudo rm -rf /tmp/curs/

[15:29:57]abalashov@abalashow-ws:~/Dropbox/develop/curseofwar/repo/curseofwar $ sudo make PREFIX=/tmp/curs/ install
install -m 755 -D curseofwar /tmp/curs//bin/curseofwar
install -m 775 -d /tmp/curs//share/man/man6
sed "s/%VERSION%/`cat VERSION`/g" curseofwar.6 | gzip -c > /tmp/curs//share/man/man6/curseofwar.6.gz
install -m 755 -d /tmp/curs//share/doc/curseofwar
cat CHANGELOG | gzip -c > /tmp/curs//share/doc/curseofwar/changelog.gz
chmod 644 /tmp/curs//share/man/man6/curseofwar.6.gz

[15:30:00]abalashov@abalashow-ws:~/Dropbox/develop/curseofwar/repo/curseofwar $ tree /tmp/curs/
/tmp/curs/
├── bin
│   └── curseofwar
└── share
    ├── doc
    │   └── curseofwar
    │       └── changelog.gz
    └── man
        └── man6
            └── curseofwar.6.gz

6 directories, 3 files
