### PR TITLE
Remove 'see how to play' from the manpage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ new
   * Added timeline plot showing populations of the countries (with option -T)
   * Install changelog.gz
   * Some installation fixes in Makefile
+  * Removed "See HOW TO PLAY" from description
 
 version 1.1.7 2013-07-22
   * Icons 32x32 and 16x16

--- a/curseofwar.6
+++ b/curseofwar.6
@@ -76,11 +76,6 @@ This is a fast-paced action strategy game for Linux implemented using ncurses us
 Unlike most RTS, you are not controlling units, but focus on high-level strategic planning: Building infrastructure, securing resources, and moving your armies.
 .PP
 The core game mechanics turns out to be quite close to WWI-WWII type of warfare, however, there is no explicit reference to any historical period.
-
-See 
-.B HOW TO PLAY
-for more details.
-
 .SH OPTIONS
 .TP
 \fB\-c\fR \fIport\fR


### PR DESCRIPTION
> The manpage (which is very nice!) says at the end of the description "See HOW
> TO PLAY for more details."  This seems to point to another file (several
> manpages do that, which I find really annoying), but actually points to another
> section in the manpage.  That is normal for a manpage: first a short
> description, then the commandline arguments, then more details.  I would remove
> this line from the end of the short description, to avoid confusion.

---

Let's do a new version. 
