### PR TITLE
Prevent division by zero

### DIFF
--- a/state.c
+++ b/state.c
@@ -292,7 +292,10 @@ void simulate(struct state *s) {
       int defender_dmg = 0;
       for(p=0; p<MAX_PLAYER; ++p){
         enemy_pop[p] = total_pop - my_pop[p];
-        int dmg = rnd_round( (float)enemy_pop[p] * my_pop[p] / total_pop );
+        int dmg = 0;
+        if(total_pop!=0) {
+          dmg = rnd_round( (float)enemy_pop[p] * my_pop[p] / total_pop );
+        }
         t[i][j].units[p][citizen] = MAX(my_pop[p] - dmg, 0);
         
         if (t[i][j].pl == p)


### PR DESCRIPTION
total_pop==0 causes undefined behavior: (float)0/0 (NaN) gets cast to
int (this conversion is not defined) and assigned to dmg.
Also, on x86 (int)NaN is INT_MIN, causing an int overflow in the next
line (-INT_MIN).