### PR TITLE
Make data files prefix-independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ endif
 VERSION=$(shell cat VERSION)
 CPPFLAGS += -DVERSION="\"$(VERSION)\""
 
+CPPFLAGS += -DINSTALL_DATA="\"$(INSTALL_DATA)/\""
+
 .PHONY: all clean cleanall
 
 # Build

--- a/path.c
+++ b/path.c
@@ -68,7 +68,7 @@ char **get_search_paths() {
   char *suffix = "/curseofwar/";
 
 #ifndef WIN32
-  int dirs_num = 7;
+  int dirs_num = 8;
   char **path = (char**) malloc(sizeof(char*) * (dirs_num + 1));
   
   path[0] = strdup("");
@@ -81,6 +81,7 @@ char **get_search_paths() {
   path[4] = strdup("/usr/share/curseofwar/");
   path[5] = strdup("/usr/share/curseofwar-sdl/");
   path[6] = strdup("/usr/share/curseofwar-common/");
+  path[7] = strdup(INSTALL_DATA);
 #else
   int dirs_num = 1;
   char **path = (char**) malloc(sizeof(char*) * (dirs_num + 1));


### PR DESCRIPTION
This patch is needed to package curseofwar for distros that do not follow the FHS (such as NixOS).