### PR TITLE
Fix memory leak in conflict()

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -449,6 +449,7 @@ int conflict (struct grid *g, struct loc loc_arr[], int available_loc_num,
 
   /* free allocated memory */
   free(sh_players);
+  free(sh_players_comp);
 
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>